### PR TITLE
Remove buttons and their reference

### DIFF
--- a/roots-nextdatagov/templates/content-contactus.php
+++ b/roots-nextdatagov/templates/content-contactus.php
@@ -12,33 +12,6 @@
 
         </div>
 
-        <div class="row contact-nav">
-
-            <ul class="nav">
-                <li class="col-md-4">
-                    <a href="#question">
-                        <i class="fa fa-comments-o"></i>
-                        <span>Ask a question</span>
-                    </a>
-                </li>
-
-                <li class="col-md-4">
-                    <a href="#request">
-                        <i class="fa fa-lightbulb-o"></i>
-                        <span>Make a Request</span>
-                    </a>
-                </li>
-
-                <li class="col-md-4">
-                    <a href="#report">
-                        <i class="fa fa-exclamation-circle"></i>
-                        <span>Report a Problem</span>
-                    </a>
-                </li>
-            </ul>
-
-        </div>
-
         <section class="row">
             <div class="col-md-12">
                 <a name="question" class="contact-heading">
@@ -143,7 +116,7 @@
                     <h1 class="icon-heading">
                         <i class="fa fa-lightbulb-o"></i>
                         <span>
-                            Make a Request
+                            Make a Request or Report a Problem
                         </span>
                     </h1>
                 </a>
@@ -161,34 +134,6 @@
                 </li>
 
                 <li class="col-md-6">
-                    <a href="/request">
-                        <i class="fa fa-check-circle-o"></i>
-                        <span>
-                            Request new data
-                        </span>
-                    </a>
-                </li>
-
-            </ul>
-
-
-        </section>
-
-        <section class="row">
-
-            <div class="col-md-12">
-                <a name="report" class="contact-heading">
-                    <h1 class="icon-heading">
-                        <i class="fa fa-exclamation-circle"></i>
-                            <span>
-                                Report a Problem
-                            </span>
-                    </h1>
-                </a>
-            </div>
-
-            <ul class="nav contact-link">
-                <li class="col-md-6">
                     <a href="https://github.com/GSA/data.gov/blob/master/CONTRIBUTING.md#ways-to-contribute">
                         <i class="fa fa-github"></i>
                             <span>
@@ -196,15 +141,10 @@
                             </span>
                     </a>
                 </li>
-                <li class="col-md-6">
-                    <a href="/issue">
-                        <i class="fa fa-exclamation-circle"></i>
-                            <span>
-                                Report a problem with a dataset
-                            </span>
-                    </a>
-                </li>
+
+
             </ul>
+
 
         </section>
     </div>


### PR DESCRIPTION
This will clean up the contacts page by removing the buttons at the top and consolidating the two sections at the bottom into one.


Still in a draft because the bottom section's icon is still a lightbulb. Unsure if we want to keep this or not

Part of [this issue](https://github.com/GSA/datagov-deploy/issues/950)