### PR TITLE
Reword copyright exemption

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Issues labeled :sparkles:[`help wanted`](https://github.com/GSA/data.gov/labels/
 
 ## Public Domain
 
-This project constitutes a work of the United States Government and is not subject to domestic copyright protection under 17 USC § 105. Additionally, we waive copyright and related rights in the work worldwide through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).
+This project constitutes a work of the United States Government and under 17 USC § 105 is not subject to domestic copyright protection. Additionally, we waive copyright and related rights in the work worldwide through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).
 
 All contributions to this project will be released under the CC0
 dedication. By submitting a pull request, you are agreeing to comply


### PR DESCRIPTION
The current text's `is not subject to` implies that `17 USC` creates copyright protection, but it's actually `17 USC` that is preventing it.